### PR TITLE
fix: ERR_CERT_INVALID for vite

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@ A simple CRM application built with Laravel 10, React.js, Inertia.js, and Tailwi
 
 -   Docker Desktop (for Windows) or Docker and Docker Compose (for Linux/macOS)
 -   Git
+-   [mkcert](https://github.com/FiloSottile/mkcert) (for generating local SSL certificates)
 
 ## Tech Stack
 
@@ -33,13 +34,39 @@ cd CRM
 
 Follow the [official Docker installation guide](https://docs.docker.com/get-docker/) for your operating system.
 
-#### Step 3: Set up the environment file
+#### Step 3: Install mkcert on Windows
+
+1. Download the latest release from the [mkcert releases page](https://github.com/FiloSottile/mkcert/releases).
+2. Extract the downloaded archive and place the `mkcert.exe` file in a directory included in your system's `PATH`.
+3. Open a terminal (recommended: Git Bash) and run the following command to install the local CA:
+
+```bash
+mkcert -install
+```
+
+4. Generate a self-signed SSL certificate for local development:
+
+```bash
+mkcert -cert-file certs/crm.localhost.crt -key-file certs/crm.localhost.key crm.localhost
+mkcert -cert-file certs/db.crm.localhost.crt -key-file certs/db.crm.localhost.key db.crm.localhost
+mkcert -cert-file certs/crm.vite.localhost.crt -key-file certs/crm.vite.localhost.key crm.vite.localhost
+```
+
+#### Step 4: Set up the environment file
 
 ```bash
 cp .env.example .env
 ```
 
-#### Step 4: Build and start the Docker containers
+Update your `.env` file with the following URLs:
+
+```env
+APP_URL=https://crm.localhost
+VITE_DEV_SERVER=true
+VITE_URL=https://crm.vite.localhost:5173
+```
+
+#### Step 5: Build and start the Docker containers
 
 ```bash
 docker-compose up -d --build
@@ -47,7 +74,7 @@ docker-compose up -d --build
 
 This command builds the Docker containers and starts them in detached mode. It also installs the necessary composer dependencies and npm dependencies. It generates a self-signed SSL certificate for local development and sets up the database. It generates the application key and runs the migrations with seeders. It also links the storage directory.
 
-#### Step 5: Access the application
+#### Step 6: Access the application
 
 You can access the application in your web browser at `https://crm.localhost` and database management at `https://db.crm.localhost`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,4 @@
 services:
-    cert-gen:
-        image: alpine:latest
-        container_name: cert-generator
-        entrypoint: /bin/sh
-        command:
-            - -c
-            - |
-                apk add --no-cache openssl && \
-                mkdir -p /etc/nginx/certs && \
-                if [ ! -f /etc/nginx/certs/crm.localhost.crt ]; then
-                openssl req -x509 -nodes -days 365 \
-                    -newkey rsa:2048 \
-                    -keyout /etc/nginx/certs/crm.localhost.key \
-                    -out /etc/nginx/certs/crm.localhost.crt \
-                    -subj "/CN=crm.localhost";
-                fi && \
-                if [ ! -f /etc/nginx/certs/db.crm.localhost.crt ]; then
-                openssl req -x509 -nodes -days 365 \
-                    -newkey rsa:2048 \
-                    -keyout /etc/nginx/certs/db.crm.localhost.key \
-                    -out /etc/nginx/certs/db.crm.localhost.crt \
-                    -subj "/CN=db.crm.localhost";
-                fi
-        volumes:
-            - ./certs:/etc/nginx/certs
-        networks:
-            - crm-net
-
     nginx-proxy:
         image: nginxproxy/nginx-proxy
         container_name: nginx-proxy
@@ -36,8 +8,6 @@ services:
         volumes:
             - /var/run/docker.sock:/tmp/docker.sock:ro
             - ./certs:/etc/nginx/certs:ro
-        depends_on:
-            - cert-gen
         networks:
             - crm-net
 
@@ -63,18 +33,17 @@ services:
         ports:
             - "5173:5173" # Vite dev server
         environment:
-            - VIRTUAL_HOST=crm.localhost
+            - VIRTUAL_HOST=crm.localhost,crm.vite.localhost
             - VIRTUAL_PORT=8000
             - APP_ENV=local
             - VITE_DEV_SERVER=true
         volumes:
             - .:/var/www/html
+            - ./certs:/etc/nginx/certs:ro
         networks:
             - crm-net
         depends_on:
             - mysql
-            # mysql:
-            #     condition: service_healthy
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
             interval: 10s
@@ -89,21 +58,6 @@ services:
             MYSQL_DATABASE: crm
             MYSQL_USER: user
             MYSQL_PASSWORD: password
-        # healthcheck:
-        #     test:
-        #         [
-        #             "CMD",
-        #             "mysqladmin",
-        #             "ping",
-        #             "-h",
-        #             "localhost",
-        #             "-u",
-        #             "root",
-        #             "-proot"
-        #         ]
-        #     interval: 10s
-        #     timeout: 5s
-        #     retries: 5
         volumes:
             - mysql-data:/var/lib/mysql
         networks:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,4 +40,4 @@ echo "✅ Application is ready at https://crm.localhost"
 
 exec php artisan serve \
   --host=0.0.0.0 \
-  --port=8000 \
+  --port=8000

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,30 @@
 import { defineConfig } from "vite";
 import laravel from "laravel-vite-plugin";
 import react from "@vitejs/plugin-react";
-import basicSsl from "@vitejs/plugin-basic-ssl";
+import fs from "fs";
 
 export default defineConfig({
     server: {
         host: "0.0.0.0", // VERY important to allow access from Docker
         port: 5173,
+        origin:
+            process.env.VITE_DEV_SERVER_URL ||
+            "https://crm.vite.localhost:5173",
         hmr: {
             protocol: "wss",
-            host: "localhost",
-            port: 5173
+            host: "crm.vite.localhost"
+        },
+        https: {
+            key: fs.readFileSync("./certs/crm.vite.localhost.key"),
+            cert: fs.readFileSync("./certs/crm.vite.localhost.crt")
+        },
+        cors: {
+            origin: [
+                process.env.APP_URL || "https://crm.localhost",
+                process.env.VITE_DEV_SERVER_URL ||
+                    "https://crm.vite.localhost:5173"
+            ],
+            credentials: true
         }
     },
     plugins: [
@@ -19,7 +33,6 @@ export default defineConfig({
             ssr: "resources/js/ssr.jsx",
             refresh: true
         }),
-        react(),
-        basicSsl() // Enable HTTPS support
+        react()
     ]
 });


### PR DESCRIPTION
docs: update README with mkcert installation instructions and SSL certificate generation steps

chore: remove cert-gen service from docker-compose and adjust nginx-proxy configuration
fix: update Vite configuration for HTTPS support and CORS settings